### PR TITLE
Implement ECharts option generator

### DIFF
--- a/echarts.py
+++ b/echarts.py
@@ -1,0 +1,73 @@
+"""Utility to generate ECharts option objects."""
+
+from typing import Any, Dict, Sequence
+
+
+def generate_option(chart_type: str, data: Any) -> Dict[str, Any]:
+    """Generate an ECharts option dictionary for a chart.
+
+    Parameters
+    ----------
+    chart_type:
+        Type of the chart: ``"line"``, ``"pie"`` or ``"bar"``.
+    data:
+        Data for the chart. For ``line`` and ``bar`` charts, ``data`` should be
+        a mapping with ``x`` and ``y`` sequences and an optional ``name`` for
+        the series. For ``pie`` charts, ``data`` should be a sequence of
+        dictionaries with ``"value"`` and ``"name"`` keys.
+
+    Returns
+    -------
+    Dict[str, Any]
+        ECharts option dictionary suitable for ``setOption``.
+
+    Raises
+    ------
+    ValueError
+        If ``chart_type`` is unsupported.
+    """
+
+    chart_type = chart_type.lower()
+    if chart_type == "line":
+        if not isinstance(data, dict) or "x" not in data or "y" not in data:
+            raise ValueError("line chart data must be a dict with 'x' and 'y'")
+        series_name = data.get("name", "")
+        return {
+            "xAxis": {"type": "category", "data": list(data["x"])},
+            "yAxis": {"type": "value"},
+            "series": [
+                {
+                    "type": "line",
+                    "name": series_name,
+                    "data": list(data["y"]),
+                }
+            ],
+        }
+    elif chart_type == "bar":
+        if not isinstance(data, dict) or "x" not in data or "y" not in data:
+            raise ValueError("bar chart data must be a dict with 'x' and 'y'")
+        series_name = data.get("name", "")
+        return {
+            "xAxis": {"type": "category", "data": list(data["x"])},
+            "yAxis": {"type": "value"},
+            "series": [
+                {
+                    "type": "bar",
+                    "name": series_name,
+                    "data": list(data["y"]),
+                }
+            ],
+        }
+    elif chart_type == "pie":
+        if not isinstance(data, Sequence):
+            raise ValueError("pie chart data must be a sequence of dicts")
+        return {
+            "series": [
+                {
+                    "type": "pie",
+                    "data": list(data),
+                }
+            ]
+        }
+
+    raise ValueError(f"Unsupported chart type: {chart_type}")

--- a/echarts.py
+++ b/echarts.py
@@ -1,6 +1,6 @@
 """Utility to generate ECharts option objects."""
 
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Iterable, Mapping
 
 
 def generate_option(chart_type: str, data: Any) -> Dict[str, Any]:
@@ -11,10 +11,11 @@ def generate_option(chart_type: str, data: Any) -> Dict[str, Any]:
     chart_type:
         Type of the chart: ``"line"``, ``"pie"`` or ``"bar"``.
     data:
-        Data for the chart. For ``line`` and ``bar`` charts, ``data`` should be
-        a mapping with ``x`` and ``y`` sequences and an optional ``name`` for
-        the series. For ``pie`` charts, ``data`` should be a sequence of
-        dictionaries with ``"value"`` and ``"name"`` keys.
+        Data for the chart. ``data`` should be a mapping containing ``labels``
+        and ``values`` sequences as well as an optional ``name``. ``labels``
+        correspond to category names (used for the x-axis of line and bar
+        charts or as slice names for pie charts) while ``values`` provide the
+        numeric values.
 
     Returns
     -------
@@ -28,44 +29,46 @@ def generate_option(chart_type: str, data: Any) -> Dict[str, Any]:
     """
 
     chart_type = chart_type.lower()
+    if not isinstance(data, Mapping) or "labels" not in data or "values" not in data:
+        raise ValueError("data must contain 'labels' and 'values'")
+
+    labels = list(data["labels"])
+    values = list(data["values"])
+    series_name = str(data.get("name", ""))
+
     if chart_type == "line":
-        if not isinstance(data, dict) or "x" not in data or "y" not in data:
-            raise ValueError("line chart data must be a dict with 'x' and 'y'")
-        series_name = data.get("name", "")
         return {
-            "xAxis": {"type": "category", "data": list(data["x"])},
+            "xAxis": {"type": "category", "data": labels},
             "yAxis": {"type": "value"},
             "series": [
                 {
                     "type": "line",
                     "name": series_name,
-                    "data": list(data["y"]),
+                    "data": values,
                 }
             ],
         }
     elif chart_type == "bar":
-        if not isinstance(data, dict) or "x" not in data or "y" not in data:
-            raise ValueError("bar chart data must be a dict with 'x' and 'y'")
-        series_name = data.get("name", "")
         return {
-            "xAxis": {"type": "category", "data": list(data["x"])},
+            "xAxis": {"type": "category", "data": labels},
             "yAxis": {"type": "value"},
             "series": [
                 {
                     "type": "bar",
                     "name": series_name,
-                    "data": list(data["y"]),
+                    "data": values,
                 }
             ],
         }
     elif chart_type == "pie":
-        if not isinstance(data, Sequence):
-            raise ValueError("pie chart data must be a sequence of dicts")
+        pie_data = [
+            {"name": label, "value": value} for label, value in zip(labels, values)
+        ]
         return {
             "series": [
                 {
                     "type": "pie",
-                    "data": list(data),
+                    "data": pie_data,
                 }
             ]
         }

--- a/main.py
+++ b/main.py
@@ -1,15 +1,19 @@
 from pprint import pprint
-
 from echarts import generate_option
-
 
 def main() -> None:
     """Demonstrate generation of ECharts option objects."""
-    line_data = {"x": ["Mon", "Tue", "Wed"], "y": [820, 932, 901], "name": "demo"}
-    pie_data = [
-        {"value": 1048, "name": "Search Engine"},
-        {"value": 735, "name": "Direct"},
-    ]
+    line_data = {
+        "labels": ["Mon", "Tue", "Wed"],
+        "values": [820, 932, 901],
+        "name": "demo",
+    }
+
+    pie_data = {
+        "labels": ["Search Engine", "Direct"],
+        "values": [1048, 735],
+        "name": "traffic",
+    }
 
     pprint(generate_option("line", line_data))
     pprint(generate_option("pie", pie_data))

--- a/main.py
+++ b/main.py
@@ -1,5 +1,18 @@
-def main():
-    print("Hello from easy-ask!")
+from pprint import pprint
+
+from echarts import generate_option
+
+
+def main() -> None:
+    """Demonstrate generation of ECharts option objects."""
+    line_data = {"x": ["Mon", "Tue", "Wed"], "y": [820, 932, 901], "name": "demo"}
+    pie_data = [
+        {"value": 1048, "name": "Search Engine"},
+        {"value": 735, "name": "Direct"},
+    ]
+
+    pprint(generate_option("line", line_data))
+    pprint(generate_option("pie", pie_data))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `generate_option` helper for creating ECharts option dictionaries
- showcase usage in `main.py`

## Testing
- `python -m py_compile echarts.py main.py`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_684443f35fb08326bf215b685af306bf