### PR TITLE
Expose generate_option as MCP tool

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,13 @@
+from echarts import generate_option
+from mcp.server.fastmcp.server import FastMCP
+import uvicorn
+
+server = FastMCP(name="easy-ask")
+
+@server.tool()
+def generate_option_tool(chart_type: str, data: dict) -> dict:
+    """Generate an ECharts option dictionary."""
+    return generate_option(chart_type, data)
+
+if __name__ == "__main__":
+    uvicorn.run(server.app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- expose `generate_option` via an MCP server

## Testing
- `python -m py_compile mcp_server.py echarts.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454ab6cad88326be61eede28ce5847